### PR TITLE
guard non-constructor calls to RArray

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ function order (a, b) {
 }
 
 function RArray () {
+  if (!(this instanceof RArray)) return new RArray()
   Scuttlebutt.call(this)
   this.keys = []
   this.store = {}


### PR DESCRIPTION
Thanks a lot for the `scuttlebutt` module family! They make it really convenient to implement P2P state replication.

This small change makes `r-array` work with [`scuttleboat`](https://github.com/kumavis/scuttleboat), because the latter calls `RArray` without `new`.

PS: Would you mind [enabling Travis CI for this module](https://travis-ci.org/dominictarr/r-array)? It's quite useful for making sure PRs don't break tests.